### PR TITLE
Use bash error handling

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+set -e -u -x
 source /opt/rpc-extras/os-ansible-deployment/scripts/scripts-library.sh
 
 export RPCD_LOGSTASH=${RPCD_LOGSTASH:-"FALSE"}
@@ -8,23 +10,23 @@ OSAD_DIR='/opt/rpc-extras/os-ansible-deployment'
 RPCD_DIR='/opt/rpc-extras/rpcd'
 
 # setup the things
-cd "${OSAD_DIR}" || exit_fail
+cd "${OSAD_DIR}"
 if [ "${RPCD_AIO}" == "yes" ]; then
-  ./scripts/bootstrap-aio.sh || exit_fail
-  cp -R "${RPCD_DIR}"/etc/openstack_deploy/* /etc/openstack_deploy/ || exit_fail
+  ./scripts/bootstrap-aio.sh
+  cp -R "${RPCD_DIR}"/etc/openstack_deploy/* /etc/openstack_deploy/
 fi
-./scripts/bootstrap-ansible.sh || exit_fail
-./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_extras_secrets.yml || exit_fail
-cd "${OSAD_DIR}"/playbooks/ || exit_fail
-install_bits setup-hosts.yml || exit_fail
+./scripts/bootstrap-ansible.sh
+./scripts/pw-token-gen.py --file /etc/openstack_deploy/user_extras_secrets.yml
+cd "${OSAD_DIR}"/playbooks/
+install_bits setup-hosts.yml
 if [ "${RPCD_AIO}" == "yes" ]; then
-  install_bits haproxy-install.yml || exit_fail
+  install_bits haproxy-install.yml
 fi
-install_bits setup-infrastructure.yml setup-openstack.yml || exit_fail
+install_bits setup-infrastructure.yml setup-openstack.yml
 
 # setup the rest
-cd "${RPCD_DIR}"/playbooks/ || exit_fail
-install_bits horizon_extensions.yml rpc-support.yml setup-maas.yml || exit_fail
+cd "${RPCD_DIR}"/playbooks/
+install_bits horizon_extensions.yml rpc-support.yml setup-maas.yml
 if [ "${RPCD_LOGSTASH}" == "yes" ]; then
-  install_bits setup-logging.yml || exit_fail
+  install_bits setup-logging.yml
 fi


### PR DESCRIPTION
Instead of adding an exit for each line, set -e to stop the script on
errors.

-x will let us see what the script was doing before it failed.

-u treats unset variables as an error when doing substitution.

These are enabled on the os-a-d scripts, and we should probably continue
using them.
